### PR TITLE
For upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ _wireguard._udp.example.com. 0	IN	PTR	yutrled535igkl7bdlerl6m4vjxsxm3uqqpl4nmsn2
 _wireguard._udp.example.com. 0	IN	PTR	wmrid55v4enhxqx2jstyoyvkicj5pihkb2tr7r42smiu3t5l4i5q====._wireguard._udp.example.com.
 $
 $ dig @127.0.0.1 -p 5353 yutrled535igkl7bdlerl6m4vjxsxm3uqqpl4nmsn27mt56ad4ha====._wireguard._udp.example.com. SRV +noall +answer +additional
-yutrled535igkl7bdlerl6m4vjxsxm3uqqpl4nmsn27mt56ad4ha====._wireguard._udp.example.com. 0	IN SRV 0 0 7777 yutrled535igkl7bdlerl6m4vjxsxm3uqqpl4nmsn27mt56ad4ha====.example.com.
-yutrled535igkl7bdlerl6m4vjxsxm3uqqpl4nmsn27mt56ad4ha====.example.com. 0	IN A 203.0.113.1
+yutrled535igkl7bdlerl6m4vjxsxm3uqqpl4nmsn27mt56ad4ha====._wireguard._udp.example.com. 0	IN SRV 0 0 7777 yutrled535igkl7bdlerl6m4vjxsxm3uqqpl4nmsn27mt56ad4ha====._wireguard._udp.example.com.
+yutrled535igkl7bdlerl6m4vjxsxm3uqqpl4nmsn27mt56ad4ha====._wireguard._udp.example.com. 0	IN A 203.0.113.1
 $
 $ dig @127.0.0.1 -p 5353 wmrid55v4enhxqx2jstyoyvkicj5pihkb2tr7r42smiu3t5l4i5q====._wireguard._udp.example.com. SRV +noall +answer +additional
-wmrid55v4enhxqx2jstyoyvkicj5pihkb2tr7r42smiu3t5l4i5q====._wireguard._udp.example.com. 0	IN SRV 0 0 8888 wmrid55v4enhxqx2jstyoyvkicj5pihkb2tr7r42smiu3t5l4i5q====.example.com.
-wmrid55v4enhxqx2jstyoyvkicj5pihkb2tr7r42smiu3t5l4i5q====.example.com. 0	IN A 198.51.100.1
+wmrid55v4enhxqx2jstyoyvkicj5pihkb2tr7r42smiu3t5l4i5q====._wireguard._udp.example.com. 0	IN SRV 0 0 8888 wmrid55v4enhxqx2jstyoyvkicj5pihkb2tr7r42smiu3t5l4i5q====._wireguard._udp.example.com.
+wmrid55v4enhxqx2jstyoyvkicj5pihkb2tr7r42smiu3t5l4i5q====._wireguard._udp.example.com. 0	IN A 198.51.100.1
 ```
 
 Converting public keys to Base64 with coreutils:

--- a/cmd/wgsd-client/main.go
+++ b/cmd/wgsd-client/main.go
@@ -3,13 +3,12 @@ package main
 import (
 	"context"
 	"encoding/base32"
-	"encoding/base64"
 	"flag"
-	"fmt"
 	"log"
 	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -24,6 +23,12 @@ var (
 	dnsServerFlag = flag.String("dns", "",
 		"ip:port of DNS server")
 	dnsZoneFlag = flag.String("zone", "", "dns zone name")
+	serviceFlag = flag.String("service", "", "service ip or public key")
+)
+
+const (
+	keyLen   = 56 // the number of characters in a base32-encoded Wireguard public key
+	spPrefix = "_wireguard._udp."
 )
 
 func main() {
@@ -64,76 +69,45 @@ func main() {
 		dnsClient := &dns.Client{
 			Timeout: time.Second * 5,
 		}
-		for _, peer := range wgDevice.Peers {
+
+		suffix := spPrefix + dns.Fqdn(*dnsZoneFlag)
+
+		if len(*serviceFlag) >= 1 {
+			fqdn := *serviceFlag
+			suffix = "." + suffix
+			if !strings.HasSuffix(fqdn, suffix) {
+				fqdn += suffix
+			}
+			ConnectPeer(ctx, wgClient, wgDevice, dnsClient, fqdn, *dnsServerFlag)
+			return
+		}
+
+		srvCtx, srvCancel := context.WithCancel(ctx)
+		m := &dns.Msg{}
+		m.SetQuestion(suffix, dns.TypePTR)
+		r, _, err := dnsClient.ExchangeContext(srvCtx, m, *dnsServerFlag)
+		srvCancel()
+		if err != nil {
+			log.Printf("failed to lookup PTR: %v", err)
+			return
+		}
+		if len(r.Answer) < 1 {
+			log.Printf("no PTR records found")
+			return
+		}
+
+		for _, answer := range r.Answer {
 			select {
 			case <-ctx.Done():
 				return
 			default:
 			}
-			srvCtx, srvCancel := context.WithCancel(ctx)
-			pubKeyBase32 := base32.StdEncoding.EncodeToString(peer.PublicKey[:])
-			pubKeyBase64 := base64.StdEncoding.EncodeToString(peer.PublicKey[:])
-			m := &dns.Msg{}
-			question := fmt.Sprintf("%s._wireguard._udp.%s",
-				pubKeyBase32, dns.Fqdn(*dnsZoneFlag))
-			m.SetQuestion(question, dns.TypeSRV)
-			r, _, err := dnsClient.ExchangeContext(srvCtx, m, *dnsServerFlag)
-			srvCancel()
-			if err != nil {
-				log.Printf(
-					"[%s] failed to lookup SRV: %v", pubKeyBase64, err)
+			ptr, ok := answer.(*dns.PTR)
+			if !ok {
+				log.Printf("non-PTR answer in response to PTR query: %s", answer.String())
 				continue
 			}
-			if len(r.Answer) < 1 {
-				log.Printf("[%s] no SRV records found", pubKeyBase64)
-				continue
-			}
-			srv, ok := r.Answer[0].(*dns.SRV)
-			if !ok {
-				log.Printf(
-					"[%s] non-SRV answer in response to SRV query: %s",
-					pubKeyBase64, r.Answer[0].String())
-			}
-			if len(r.Extra) < 1 {
-				log.Printf("[%s] SRV response missing extra A/AAAA",
-					pubKeyBase64)
-			}
-			var endpointIP net.IP
-			hostA, ok := r.Extra[0].(*dns.A)
-			if !ok {
-				hostAAAA, ok := r.Extra[0].(*dns.AAAA)
-				if !ok {
-					log.Printf(
-						"[%s] non-A/AAAA extra in SRV response: %s",
-						pubKeyBase64, r.Extra[0].String())
-					continue
-				}
-				endpointIP = hostAAAA.AAAA
-			} else {
-				endpointIP = hostA.A
-			}
-			peerConfig := wgtypes.PeerConfig{
-				PublicKey:  peer.PublicKey,
-				UpdateOnly: true,
-				Endpoint: &net.UDPAddr{
-					IP:   endpointIP,
-					Port: int(srv.Port),
-				},
-			}
-			deviceConfig := wgtypes.Config{
-				PrivateKey:   &wgDevice.PrivateKey,
-				ReplacePeers: false,
-				Peers:        []wgtypes.PeerConfig{peerConfig},
-			}
-			if wgDevice.FirewallMark > 0 {
-				deviceConfig.FirewallMark = &wgDevice.FirewallMark
-			}
-			err = wgClient.ConfigureDevice(*deviceFlag, deviceConfig)
-			if err != nil {
-				log.Printf(
-					"[%s] failed to configure peer on %s, error: %v",
-					pubKeyBase64, *deviceFlag, err)
-			}
+			ConnectPeer(ctx, wgClient, wgDevice, dnsClient, ptr.Ptr, *dnsServerFlag)
 		}
 	}()
 	sigCh := make(chan os.Signal, 1)
@@ -145,4 +119,105 @@ func main() {
 		<-done
 	case <-done:
 	}
+}
+
+func ConnectPeer(ctx context.Context, wgClient *wgctrl.Client, wgDevice *wgtypes.Device, dnsClient *dns.Client, serviceFqdn string, dnsServer string) {
+	srvCtx, srvCancel := context.WithCancel(ctx)
+	m := &dns.Msg{}
+	m.SetQuestion(serviceFqdn, dns.TypeSRV)
+	r, _, err := dnsClient.ExchangeContext(srvCtx, m, dnsServer)
+	srvCancel()
+	if err != nil {
+		log.Printf(
+			"[%s] failed to lookup SRV: %v", serviceFqdn, err)
+		return
+	}
+	if len(r.Answer) < 1 {
+		log.Printf("[%s] no SRV records found", serviceFqdn)
+		return
+	}
+	srv, ok := r.Answer[0].(*dns.SRV)
+	if !ok {
+		log.Printf(
+			"[%s] non-SRV answer in response to SRV query: %s",
+			serviceFqdn, r.Answer[0].String())
+		return
+	}
+	if len(r.Extra) < 2 {
+		log.Printf("[%s] SRV response missing extra A/AAAA and TXT",
+			serviceFqdn)
+		return
+	}
+	var endpointIP net.IP
+	hostA, ok := r.Extra[0].(*dns.A)
+	if !ok {
+		hostAAAA, ok := r.Extra[0].(*dns.AAAA)
+		if !ok {
+			log.Printf(
+				"[%s] non-A/AAAA extra in SRV response: %s",
+				serviceFqdn, r.Extra[0].String())
+			return
+		}
+		endpointIP = hostAAAA.AAAA
+	} else {
+		endpointIP = hostA.A
+	}
+	txt, ok := r.Extra[1].(*dns.TXT)
+	if !ok {
+		log.Printf("[%s] non-TXT extra in SRV response: %s",
+			serviceFqdn, r.Extra[1].String())
+		return
+	}
+	allowedIPsString := strings.TrimPrefix(strings.ToLower(txt.Txt[0]), "allowedip=")
+	_, allowedIPs, err := net.ParseCIDR(allowedIPsString)
+	if err != nil {
+		log.Printf("[%s] failed to parse allowedip in TXT extra: %s", serviceFqdn, r.Extra[1].String())
+		return
+	}
+	pubKeyString := strings.TrimPrefix(strings.ToUpper(txt.Txt[1]), "PUBKEY=")
+	if len(pubKeyString) < keyLen {
+		pubKeyString += strings.Repeat("=", keyLen-len(pubKeyString))
+	}
+	pubKeyBytes, err := base32.StdEncoding.DecodeString(strings.ToUpper(pubKeyString))
+	if err != nil {
+		log.Printf("[%s] failed to decode base32 key %s: %v", serviceFqdn, pubKeyString, err)
+		return
+	}
+	pubKeyWg, err := wgtypes.NewKey(pubKeyBytes)
+	if err != nil {
+		log.Printf("[%s] failed to create wg key: %v", serviceFqdn, err)
+		return
+	}
+	if pubKeyWg == wgDevice.PublicKey {
+		log.Printf("[%s] skipping ourself", serviceFqdn)
+		return
+	}
+
+	peerConfig := wgtypes.PeerConfig{
+		PublicKey:  pubKeyWg,
+		UpdateOnly: false,
+		Endpoint: &net.UDPAddr{
+			IP:   endpointIP,
+			Port: int(srv.Port),
+		},
+		ReplaceAllowedIPs: true,
+		AllowedIPs:        []net.IPNet{*allowedIPs},
+	}
+	deviceConfig := wgtypes.Config{
+		PrivateKey:   &wgDevice.PrivateKey,
+		ReplacePeers: false,
+		Peers:        []wgtypes.PeerConfig{peerConfig},
+	}
+	if wgDevice.FirewallMark > 0 {
+		deviceConfig.FirewallMark = &wgDevice.FirewallMark
+	}
+	err = wgClient.ConfigureDevice(*deviceFlag, deviceConfig)
+	if err != nil {
+		log.Printf(
+			"[%s] failed to configure peer on %s, error: %v",
+			serviceFqdn, *deviceFlag, err)
+		return
+	}
+
+	log.Printf("[%s] configure peer on %s", serviceFqdn, *deviceFlag)
 }

--- a/vagrant/Corefile
+++ b/vagrant/Corefile
@@ -1,0 +1,6 @@
+.:5353 {
+  debug
+  bind 127.0.0.1
+  bind 192.168.100.10
+  wgsd example.com. wg0
+}

--- a/vagrant/README
+++ b/vagrant/README
@@ -1,0 +1,11 @@
+Quick start instructions
+
+Clone & build wgsd:
+~# go get github.com/jwhited/wgsd
+
+Start and provision VMs with Vagrant:
+~# cd ~/go/src/github.com/jwhited/wgsd/vagrant
+~# vagrant up
+
+Setup Wireguard Mesh:
+~# ./setup.sh

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,54 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+
+  config.trigger.before :up do |trigger|
+      trigger.run = {inline: "cp -uvf ../../../../../bin/coredns ../../../../../bin/wgsd-client ."}
+  end
+
+  config.vm.box = "ubuntu/focal64"
+  config.vm.box_check_update = false
+
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get -y update
+    apt-get -y install wireguard
+  SHELL
+
+  config.vm.define "registry" do |registry|
+    registry.vm.hostname = "registry"
+    registry.vm.network "private_network", ip: "192.168.33.10"
+    registry.vm.provision "shell", inline: <<-SHELL
+      wg genkey | tee /etc/wireguard/privatekey | wg pubkey | tee /etc/wireguard/publickey
+      cat > /etc/wireguard/wg0.conf << EOF
+[Interface]
+PrivateKey = $(cat /etc/wireguard/privatekey)
+Address = 192.168.100.10/24
+SaveConfig = True
+ListenPort = 51820
+EOF
+      chmod 600 /etc/wireguard/{privatekey,wg0.conf}
+      chmod 644 /etc/wireguard/publickey
+      chmod 711 /etc/wireguard
+      systemctl enable wg-quick@wg0
+      systemctl start wg-quick@wg0
+      cat > /etc/rc.local << EOF
+#!/bin/sh
+/vagrant/coredns -conf /vagrant/Corefile | logger &
+EOF
+      chmod 755 /etc/rc.local
+      sleep 1
+      /etc/rc.local
+    SHELL
+  end
+
+  (1..4).each do |i|
+      config.vm.define "client-#{i}" do |client|
+          client.vm.hostname = "client-#{i}"
+          client.vm.network "private_network", ip: "192.168.33.10#{i}"
+      end
+  end
+
+end

--- a/vagrant/add.sh
+++ b/vagrant/add.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eux
+VM=$1
+ADDR=$2
+
+SERVER_KEY=$(vagrant ssh registry -- cat /etc/wireguard/publickey)
+
+vagrant ssh $VM -- sudo bash -s << EOF
+wg genkey | tee /etc/wireguard/privatekey | wg pubkey | tee /etc/wireguard/publickey
+# linux  config
+cat > /etc/wireguard/wg0.conf << CLIENTEOF
+[Interface]
+PrivateKey = \$(cat /etc/wireguard/privatekey)
+Address = $ADDR/24
+ListenPort = 51820
+[Peer]
+PublicKey = $SERVER_KEY
+Endpoint = 192.168.33.10:51820
+AllowedIPs = 192.168.100.10/32
+CLIENTEOF
+chmod 600 /etc/wireguard/{privatekey,wg0.conf}
+chmod 644 /etc/wireguard/publickey
+chmod 711 /etc/wireguard
+EOF
+
+CLIENT_KEY=$(vagrant ssh $VM -- cat /etc/wireguard/publickey)
+
+vagrant ssh registry -- sudo wg set wg0 peer $CLIENT_KEY allowed-ips $ADDR/32
+
+vagrant ssh $VM -- sudo systemctl enable wg-quick@wg0
+vagrant ssh $VM -- sudo systemctl restart wg-quick@wg0
+vagrant ssh $VM -- ping -c2 192.168.100.10

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -eux
+
+PEER_NR=4
+
+for ((i=1;i<=$PEER_NR;i++));do
+    ./add.sh client-$i 192.168.100.10$i
+done
+
+for ((i=1;i<=$PEER_NR;i++));do
+    vagrant ssh client-$i -- sudo /vagrant/wgsd-client -device wg0 -dns 192.168.100.10:5353 -zone example.com.
+done
+
+for ((i=1;i<=$PEER_NR;i++));do
+    vagrant ssh client-$i -- ping -c2 192.168.100.10
+    for ((j=1;j<=$PEER_NR;j++));do
+        vagrant ssh client-$i -- ping -c2 192.168.100.10$j
+    done
+done

--- a/wgsd.go
+++ b/wgsd.go
@@ -37,7 +37,8 @@ type wgctrlClient interface {
 const (
 	keyLen             = 56 // the number of characters in a base32-encoded Wireguard public key
 	spPrefix           = "_wireguard._udp."
-	serviceInstanceLen = keyLen + len(".") + len(spPrefix)
+	spSubPrefix        = "." + spPrefix
+	serviceInstanceLen = keyLen + len(spSubPrefix)
 )
 
 func (p *WGSD) ServeDNS(ctx context.Context, w dns.ResponseWriter,
@@ -114,15 +115,14 @@ func (p *WGSD) ServeDNS(ctx context.Context, w dns.ResponseWriter,
 					Priority: 0,
 					Weight:   0,
 					Port:     uint16(endpoint.Port),
-					Target: fmt.Sprintf("%s.%s",
-						strings.ToLower(pubKey), p.zone),
+					Target:   pubKey + spSubPrefix + p.zone,
 				})
 				w.WriteMsg(m) // nolint: errcheck
 				return dns.RcodeSuccess, nil
 			}
 		}
 		return nxDomain(p.zone, w, r)
-	case len(name) == keyLen+1 && (qtype == dns.TypeA ||
+	case len(name) == len(spSubPrefix)+keyLen && (qtype == dns.TypeA ||
 		qtype == dns.TypeAAAA):
 		pubKey := name[:keyLen]
 		for _, peer := range device.Peers {
@@ -148,7 +148,7 @@ func getHostRR(pubKey, zone string, endpoint *net.UDPAddr) dns.RR {
 	if endpoint == nil || endpoint.IP == nil {
 		return nil
 	}
-	name := fmt.Sprintf("%s.%s", strings.ToLower(pubKey), zone)
+	name := strings.ToLower(pubKey) + spSubPrefix + zone
 	switch {
 	case endpoint.IP.To4() != nil:
 		return &dns.A{

--- a/wgsd.go
+++ b/wgsd.go
@@ -35,11 +35,12 @@ type wgctrlClient interface {
 }
 
 const (
-	keyLen             = 56 // the number of characters in a base32-encoded Wireguard public key
-	spPrefix           = "_wireguard._udp."
-	spSubPrefix        = "." + spPrefix
-	serviceInstanceLen = keyLen + len(spSubPrefix)
+	keyLen      = 56 // the number of characters in a base32-encoded Wireguard public key
+	spPrefix    = "_wireguard._udp."
+	spSubPrefix = "." + spPrefix
 )
+
+var emptySubnet = net.IPNet{IP: net.IPv4zero, Mask: net.IPv4Mask(0, 0, 0, 0)}
 
 func (p *WGSD) ServeDNS(ctx context.Context, w dns.ResponseWriter,
 	r *dns.Msg) (int, error) {
@@ -94,32 +95,61 @@ func (p *WGSD) ServeDNS(ctx context.Context, w dns.ResponseWriter,
 		}
 		w.WriteMsg(m) // nolint: errcheck
 		return dns.RcodeSuccess, nil
-	case len(name) == serviceInstanceLen && qtype == dns.TypeSRV:
-		pubKey := name[:keyLen]
+	case qtype == dns.TypeSRV && strings.HasSuffix(name, spSubPrefix):
+		name = name[:len(name)-len(spSubPrefix)]
+		logger.Debugf("received query for: %s type: %s", name,
+			dns.TypeToString[qtype])
 		for _, peer := range device.Peers {
-			if strings.EqualFold(
-				base32.StdEncoding.EncodeToString(peer.PublicKey[:]), pubKey) {
-				endpoint := peer.Endpoint
-				hostRR := getHostRR(pubKey, p.zone, endpoint)
-				if hostRR == nil {
-					return nxDomain(p.zone, w, r)
-				}
-				m.Extra = append(m.Extra, hostRR)
-				m.Answer = append(m.Answer, &dns.SRV{
-					Hdr: dns.RR_Header{
-						Name:   state.Name(),
-						Rrtype: dns.TypeSRV,
-						Class:  dns.ClassINET,
-						Ttl:    0,
-					},
-					Priority: 0,
-					Weight:   0,
-					Port:     uint16(endpoint.Port),
-					Target:   pubKey + spSubPrefix + p.zone,
-				})
-				w.WriteMsg(m) // nolint: errcheck
-				return dns.RcodeSuccess, nil
+			pubKey := base32.StdEncoding.EncodeToString(peer.PublicKey[:])
+			allowedIPs := &emptySubnet
+			if len(peer.AllowedIPs) >= 1 {
+				allowedIPs = &peer.AllowedIPs[0]
 			}
+			if len(name) == keyLen {
+				// check by keyname
+				if !strings.EqualFold(pubKey, name[:keyLen]) {
+					continue
+				}
+			} else {
+				// check by ip
+				ip := net.ParseIP(name)
+				if ip == nil || !allowedIPs.Contains(ip) {
+					continue
+				}
+			}
+			endpoint := peer.Endpoint
+			hostRR := getHostRR(pubKey, p.zone, endpoint)
+			if hostRR == nil {
+				return nxDomain(p.zone, w, r)
+			}
+			m.Extra = append(m.Extra, hostRR)
+			pubKey = strings.ToLower(pubKey)
+			m.Extra = append(m.Extra, &dns.TXT{
+				Hdr: dns.RR_Header{
+					Name:   state.Name(),
+					Rrtype: dns.TypeTXT,
+					Class:  dns.ClassINET,
+					Ttl:    0,
+				},
+				Txt: []string{
+					"allowedip=" + allowedIPs.String(),
+					"pubkey=" + strings.TrimRight(pubKey, "="),
+				},
+			})
+			m.Answer = append(m.Answer, &dns.SRV{
+				Hdr: dns.RR_Header{
+					Name:   state.Name(),
+					Rrtype: dns.TypeSRV,
+					Class:  dns.ClassINET,
+					Ttl:    0,
+				},
+				Priority: 0,
+				Weight:   0,
+				Port:     uint16(endpoint.Port),
+				Target:   pubKey + spSubPrefix + p.zone,
+			})
+			w.WriteMsg(m) // nolint: errcheck
+			return dns.RcodeSuccess, nil
 		}
 		return nxDomain(p.zone, w, r)
 	case len(name) == len(spSubPrefix)+keyLen && (qtype == dns.TypeA ||

--- a/wgsd_test.go
+++ b/wgsd_test.go
@@ -70,10 +70,10 @@ func TestWGSD(t *testing.T) {
 			Qtype: dns.TypeSRV,
 			Rcode: dns.RcodeSuccess,
 			Answer: []dns.RR{
-				test.SRV(fmt.Sprintf("%s._wireguard._udp.example.com. 0 IN SRV 0 0 1 %s.example.com.", peer1b32, peer1b32)),
+				test.SRV(fmt.Sprintf("%s._wireguard._udp.example.com. 0 IN SRV 0 0 1 %s._wireguard._udp.example.com.", peer1b32, peer1b32)),
 			},
 			Extra: []dns.RR{
-				test.A(fmt.Sprintf("%s.example.com. 0 IN A %s", peer1b32, peer1.Endpoint.IP.String())),
+				test.A(fmt.Sprintf("%s._wireguard._udp.example.com. 0 IN A %s", peer1b32, peer1.Endpoint.IP.String())),
 			},
 		},
 		{
@@ -81,26 +81,26 @@ func TestWGSD(t *testing.T) {
 			Qtype: dns.TypeSRV,
 			Rcode: dns.RcodeSuccess,
 			Answer: []dns.RR{
-				test.SRV(fmt.Sprintf("%s._wireguard._udp.example.com. 0 IN SRV 0 0 2 %s.example.com.", peer2b32, peer2b32)),
+				test.SRV(fmt.Sprintf("%s._wireguard._udp.example.com. 0 IN SRV 0 0 2 %s._wireguard._udp.example.com.", peer2b32, peer2b32)),
 			},
 			Extra: []dns.RR{
-				test.AAAA(fmt.Sprintf("%s.example.com. 0 IN AAAA %s", peer2b32, peer2.Endpoint.IP.String())),
+				test.AAAA(fmt.Sprintf("%s._wireguard._udp.example.com. 0 IN AAAA %s", peer2b32, peer2.Endpoint.IP.String())),
 			},
 		},
 		{
-			Qname: fmt.Sprintf("%s.example.com.", peer1b32),
+			Qname: fmt.Sprintf("%s._wireguard._udp.example.com.", peer1b32),
 			Qtype: dns.TypeA,
 			Rcode: dns.RcodeSuccess,
 			Answer: []dns.RR{
-				test.A(fmt.Sprintf("%s.example.com. 0 IN A %s", peer1b32, peer1.Endpoint.IP.String())),
+				test.A(fmt.Sprintf("%s._wireguard._udp.example.com. 0 IN A %s", peer1b32, peer1.Endpoint.IP.String())),
 			},
 		},
 		{
-			Qname: fmt.Sprintf("%s.example.com.", peer2b32),
+			Qname: fmt.Sprintf("%s._wireguard._udp.example.com.", peer2b32),
 			Qtype: dns.TypeAAAA,
 			Rcode: dns.RcodeSuccess,
 			Answer: []dns.RR{
-				test.AAAA(fmt.Sprintf("%s.example.com. 0 IN AAAA %s", peer2b32, peer2.Endpoint.IP.String())),
+				test.AAAA(fmt.Sprintf("%s._wireguard._udp.example.com. 0 IN AAAA %s", peer2b32, peer2.Endpoint.IP.String())),
 			},
 		},
 		{


### PR DESCRIPTION
Hi Jordan,  wgsd is a great project!

Here are some proposals, I'd be curious to get your feedback:
 - consistently use Service Instance Name as <Instance> . <Service> . <Domain> everywhere. I noted the fields in A/AAAA and SRV fields are resolved through Service Instance Name but are returned as <Instance> . <Domain>
 - update wgsd DNS plugin to allow peer auto-configuration: I added a TXT field in the SRV answer to communicate the allowed ip and pubkey. That way, the peers do not have to know other peers configuration before-hand
 - update wgsd-client to use service auto-configuration: wgsd-client can connect to all advertised peers or only to a selected peer
 - add a vagrant environment to easily play around

Best,
ben