### PR TITLE
encoding: allow to use sha1 and a short sha1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,25 @@ A basic client is available under [cmd/wgsd-client](cmd/wgsd-client).
 ## Configuration Syntax
 
 ```
-wgsd ZONE DEVICE
+wgsd ZONE DEVICE ENCODING
 ```
 
 ## Querying
 
-Following RFC6763 this plugin provides a listing of peers via PTR records at the namespace `_wireguard._udp.<zone>`. The target for the PTR records is `<base32PubKey>._wireguard._udp.<zone>` which corresponds to SRV records. SRV targets are of the format `<base32PubKey>.<zone>`. When querying the SRV record for a peer, the target A/AAAA records will be included in the "additional" section of the response. Public keys are represented in Base32 rather than Base64 to allow for their use in node names where they are treated as case-insensitive by the DNS.
+Following RFC6763 this plugin provides a listing of peers via PTR records at the namespace `_wireguard._udp.<zone>`. The target for the PTR records is `<$encodingPubKey>._wireguard._udp.<zone>` which corresponds to SRV records. SRV targets are of the format `<base32PubKey>.<zone>`. When querying the SRV record for a peer, the target A/AAAA records will be included in the "additional" section of the response. Public keys are represented in the chosen encoding rather than original Base64 human representation to allow for their use in node names where they are treated as case-insensitive by the DNS.
+
+The supported encoding settings are:
+* base32 `b32`
+* hexadecimal `hex`
+* sha1 `sha1`
+
+Truncation, for example route53 restricts its record maximum size, to keep consistency with these setup limitation, wgsd supports truncation. This truncation could be compared to a short git sha1. 
+
+The supported encoding truncation are:
+* hexadecimal - e.g.: `hex:7`
+* sha1 - e.g: `sha1:9`
+
+Note that the sha1 and truncation allows to obfuscate peers public keys. 
 
 ## Example
 
@@ -42,7 +55,7 @@ This configuration:
 ```
 $ cat Corefile
 .:5353 {
-  wgsd example.com. wg0
+  wgsd example.com. wg0 b32
 }
 ```
 

--- a/encoder.go
+++ b/encoder.go
@@ -1,0 +1,77 @@
+package wgsd
+
+import (
+	"crypto/sha1"
+	"encoding/base32"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type encoder interface {
+	EncodeToString([]byte) string
+}
+
+func getEncoder(e string) (encoder, error) {
+	parts := strings.Split(e, ":")
+	if len(parts) > 2 {
+		return nil, errors.New("failed to parse encoder")
+	}
+	name := parts[0]
+	if len(parts) == 1 {
+		return buildEncoder(name, 0)
+	}
+	trunc, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, err
+	}
+	if trunc < 0 {
+		return nil, errors.New("truncation value is < 0")
+	}
+	return buildEncoder(name, trunc)
+}
+
+func buildEncoder(name string, trunc int) (encoder, error) {
+	switch name {
+	case "b32":
+		if trunc != 0 {
+			return nil, fmt.Errorf("%s doesn't support truncation", name)
+		}
+		return base32.StdEncoding, nil
+	case "sha1":
+		return &shaOne{trunc: trunc}, nil
+	case "hex":
+		return &hexa{trunc: trunc}, nil
+	default:
+		return nil, errors.New("invalid encoder")
+	}
+}
+
+type shaOne struct {
+	trunc int
+}
+
+func (e *shaOne) EncodeToString(b []byte) string {
+	h := sha1.New()
+	_, _ = h.Write(b)
+	sum := h.Sum(nil)
+	r := hex.EncodeToString(sum)
+	if e.trunc == 0 || len(r) < e.trunc {
+		return r
+	}
+	return r[:e.trunc]
+}
+
+type hexa struct {
+	trunc int
+}
+
+func (e *hexa) EncodeToString(b []byte) string {
+	r := hex.EncodeToString(b)
+	if e.trunc == 0 || len(r) < e.trunc {
+		return r
+	}
+	return r[:e.trunc]
+}

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/coredns/caddy v1.1.0
 	github.com/coredns/coredns v1.8.0
 	github.com/miekg/dns v1.1.34
+	github.com/stretchr/testify v1.4.0
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200511024508-91d9787b944f
 )

--- a/setup.go
+++ b/setup.go
@@ -19,15 +19,23 @@ func setup(c *caddy.Controller) error {
 
 	// return an error if there is no zone specified
 	if !c.NextArg() {
-		return plugin.Error("wgsd", c.ArgErr())
+		return plugin.Error("wgsd", fmt.Errorf("missing zone: %v", c.ArgErr()))
 	}
 	zone := dns.Fqdn(c.Val())
 
 	// return an error if there is no device name specified
 	if !c.NextArg() {
-		return plugin.Error("wgsd", c.ArgErr())
+		return plugin.Error("wgsd", fmt.Errorf("missing wireguard device name: %v", c.ArgErr()))
 	}
 	device := c.Val()
+
+	if !c.NextArg() {
+		return plugin.Error("wgsd", fmt.Errorf("missing wireguard public key encoding: %v", c.ArgErr()))
+	}
+	enc, err := getEncoder(c.Val())
+	if err != nil {
+		return plugin.Error("wgsd", fmt.Errorf("unsupported wireguard public key encoding: %v", err))
+	}
 
 	// return an error if there are more tokens on this line
 	if c.NextArg() {
@@ -48,6 +56,7 @@ func setup(c *caddy.Controller) error {
 			client: client,
 			zone:   zone,
 			device: device,
+			enc:    enc,
 		}
 	})
 

--- a/setup_test.go
+++ b/setup_test.go
@@ -13,9 +13,39 @@ func TestSetup(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			"valid input",
-			"wgsd example.com. wg0",
+			"valid input b32",
+			"wgsd example.com. wg0 b32",
 			false,
+		},
+		{
+			"valid input sha1",
+			"wgsd example.com. wg0 sha1",
+			false,
+		},
+		{
+			"valid input hex",
+			"wgsd example.com. wg0 hex",
+			false,
+		},
+		{
+			"valid input sha1 truncate",
+			"wgsd example.com. wg0 sha1:7",
+			false,
+		},
+		{
+			"valid input hex truncate",
+			"wgsd example.com. wg0 hex:7",
+			false,
+		},
+		{
+			"valid input hex truncate",
+			"wgsd example.com. wg0 hex:-1",
+			true,
+		},
+		{
+			"invalid input b32 truncate",
+			"wgsd example.com. wg0 b32:7",
+			true,
 		},
 		{
 			"missing token",
@@ -24,7 +54,7 @@ func TestSetup(t *testing.T) {
 		},
 		{
 			"too many tokens",
-			"wgsd example.com. wg0 extra",
+			"wgsd example.com. wg0 b32 extra",
 			true,
 		},
 	}


### PR DESCRIPTION
First, thank you very much for doing this work, especially the blogpost which is a really great read.

This PR allows to select a different encoder.

The sha1/hex encoder can be truncated like we're used to observe with git, it'll produce convenient shorter SRV/A records.