### PR TITLE
setup: on shutdown, close the client connection

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -40,6 +40,7 @@ func setup(c *caddy.Controller) error {
 			fmt.Errorf("error constructing wgctrl client: %v",
 				err))
 	}
+	c.OnFinalShutdown(client.Close)
 
 	// Add the Plugin to CoreDNS, so Servers can use it in their plugin chain.
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {


### PR DESCRIPTION
This PR is pretty straightforward, it closes the wireguard client when the server is shutting down.

I wonder if anyone encountered any issues while coredns is running for a while, as we just create it once in the setup.