### PR TITLE
Adds option to only propagate peers that expose a subnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ wgsd ZONE DEVICE {
 ```
 
 * Supplying the `self` option enables serving data about the local WireGuard device in addition to its peers. The optional `ENDPOINT` argument enables setting a custom endpoint in ip:port form. If `ENDPOINT` is omitted wgsd will default to the local IP address for the DNS query and `ListenPort` of the WireGuard device. This can be useful if your host is behind NAT. The optional, variadic `ALLOWED-IPS` argument sets allowed-ips to be served for the local WireGuard device.
-* Supplying the optional `only-propagate-subnets` will mean that the registry will only respond to querries with peers that have more than one address listed in their `AllowedIPs`. For example it would responds with peers containing `AllowedIPs=192.168.10.0/24` or `AllowedIPs=192.168.10.2/32, 192.168.10.11/32` but not a peer with `AllowedIPs=192.168.20.1/32`
+* Supplying the optional `only-propagate-subnets` will mean that the registry will only respond to querries with peers that have more than one address listed in their `AllowedIPs`. For example it would responds with peers containing `AllowedIPs=192.168.10.0/24` or `AllowedIPs=192.168.10.2/32, 192.168.10.11/32` but not a peer with `AllowedIPs=192.168.20.1/32`. __WARNING:__ with its current implementation if a peer has its IPv4 address and IPv6 this will count as two and will be propagated `AllowedIPs=192.168.20.1/32, 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128`
 
 ## Querying
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ wgsd ZONE DEVICE
 
 ```
 wgsd ZONE DEVICE {
-    self [ ENDPOINT ] [ ALLOWED-IPS ... ]
+   only-propagate-subnets self [ ENDPOINT ] [ ALLOWED-IPS ... ]
 }
 ```
 
 * Supplying the `self` option enables serving data about the local WireGuard device in addition to its peers. The optional `ENDPOINT` argument enables setting a custom endpoint in ip:port form. If `ENDPOINT` is omitted wgsd will default to the local IP address for the DNS query and `ListenPort` of the WireGuard device. This can be useful if your host is behind NAT. The optional, variadic `ALLOWED-IPS` argument sets allowed-ips to be served for the local WireGuard device.
+* Supplying the optional `only-propagate-subnets` will mean that the registry will only respond to querries with peers that have more than one address listed in their `AllowedIPs`. For example it would responds with peers containing `AllowedIPs=192.168.10.0/24` or `AllowedIPs=192.168.10.2/32, 192.168.10.11/32` but not a peer with `AllowedIPs=192.168.20.1/32`
 
 ## Querying
 

--- a/setup.go
+++ b/setup.go
@@ -39,7 +39,10 @@ func parse(c *caddy.Controller) (Zones, error) {
 		z[zone.name] = zone
 
 		for c.NextBlock() {
+			zone.onlySubnets = false
 			switch c.Val() {
+			case "only-propagate-subnets":
+				zone.onlySubnets = true
 			case "self":
 				// self [endpoint] [allowed-ips ... ]
 				zone.serveSelf = true

--- a/wgsd.go
+++ b/wgsd.go
@@ -5,9 +5,9 @@ import (
 	"encoding/base32"
 	"encoding/base64"
 	"fmt"
+	"math"
 	"net"
 	"strings"
-	"math"
 
 	"github.com/coredns/coredns/plugin"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
@@ -42,7 +42,7 @@ type Zone struct {
 	serveSelf      bool         // flag to enable serving data about self
 	selfEndpoint   *net.UDPAddr // overrides the self endpoint value
 	selfAllowedIPs []net.IPNet  // self allowed IPs
-	onlySubnets    bool	    //
+	onlySubnets    bool         //
 }
 
 type wgctrlClient interface {
@@ -178,7 +178,7 @@ func getSelfPeer(zone *Zone, device *wgtypes.Device, state request.Request) (wgt
 	return self, nil
 }
 
-// takes a list of IPNets e.g "192.168.0.2/32" and 
+// takes a list of IPNets e.g "192.168.0.2/32" and
 // and the total number of addresses exposed float64
 // assumed that the networks do not overlap
 func networkSizes(ips []net.IPNet) float64 {
@@ -186,7 +186,7 @@ func networkSizes(ips []net.IPNet) float64 {
 	for _, ip := range ips {
 		ones, bits := ip.Mask.Size()
 		bitsize := (bits - ones)
-		tot += math.Pow(2,float64(bitsize))
+		tot += math.Pow(2, float64(bitsize))
 	}
 	return tot
 }
@@ -201,7 +201,7 @@ func getPeers(client wgctrlClient, zone *Zone, state request.Request) (
 	if !zone.onlySubnets {
 		peers = append(peers, device.Peers...)
 	} else {
-		for _, peer := range device.Peers{
+		for _, peer := range device.Peers {
 			if t := networkSizes(peer.AllowedIPs); t > 1 { // could be more complex, e.g allow user to specify a threshold
 				peers = append(peers, peer)
 			}
@@ -223,7 +223,7 @@ func (p *WGSD) ServeDNS(ctx context.Context, w dns.ResponseWriter,
 	// ResponseWriter.
 	state := request.Request{W: w, Req: r}
 
-	// Check if the request is 
+	// Check if the request is
 	//a zone we are serving. If it doesn't match we
 	// pass the request on to the next plugin.
 	zoneName := plugin.Zones(p.Names).Matches(state.Name())

--- a/wgsd.go
+++ b/wgsd.go
@@ -201,7 +201,7 @@ func getPeers(client wgctrlClient, zone *Zone, state request.Request) (
 	if !zone.onlySubnets {
 		peers = append(peers, device.Peers...)
 	} else {
-		for _, peer in range device.Peers{
+		for _, peer := range device.Peers{
 			if t := networkSizes(networks); t > 1 { // could be more complex, e.g allow user to specify a threshold
 				peers = append(peers, peer)
 			}

--- a/wgsd.go
+++ b/wgsd.go
@@ -181,7 +181,7 @@ func getSelfPeer(zone *Zone, device *wgtypes.Device, state request.Request) (wgt
 // takes a list of IPNets e.g "192.168.0.2/32" and 
 // and the total number of addresses exposed float64
 // assumed that the networks do not overlap
-func networkSizes(ips []*net.IPNet) float64 {
+func networkSizes(ips []net.IPNet) float64 {
 	var tot float64
 	for _, ip := range ips {
 		ones, bits := ip.Mask.Size()

--- a/wgsd.go
+++ b/wgsd.go
@@ -202,7 +202,7 @@ func getPeers(client wgctrlClient, zone *Zone, state request.Request) (
 		peers = append(peers, device.Peers...)
 	} else {
 		for _, peer := range device.Peers{
-			if t := networkSizes(networks); t > 1 { // could be more complex, e.g allow user to specify a threshold
+			if t := networkSizes(peer.AllowedIPs); t > 1 { // could be more complex, e.g allow user to specify a threshold
 				peers = append(peers, peer)
 			}
 		}


### PR DESCRIPTION
This would allow for a registry to propagate 'sites' for a (site-to-site mesh) that expose a whole subnet whilst also allowing single devices to connect to the registry as spokes

https://github.com/jwhited/wgsd/issues/35

__WARNING__: I could not get the dev environment to run on my PC so the code is untested. I tested what I could in the go playground