### PR TITLE
Added ability for wgsd-client to work over tcp via optional protocol flag

### DIFF
--- a/cmd/wgsd-client/README.md
+++ b/cmd/wgsd-client/README.md
@@ -10,4 +10,6 @@ Usage of ./wgsd-client:
     	ip:port of DNS server
   -zone string
     	dns zone name
+  -protocol string (optional)
+      udp (default) or tcp
 ```

--- a/cmd/wgsd-client/main.go
+++ b/cmd/wgsd-client/main.go
@@ -24,6 +24,8 @@ var (
 	dnsServerFlag = flag.String("dns", "",
 		"ip:port of DNS server")
 	dnsZoneFlag = flag.String("zone", "", "dns zone name")
+	// Adding optional protocol flag to specify protocol to use
+	protocolFlag = flag.String("protocol", "", "optional: tcp or udp (default)")
 )
 
 func main() {
@@ -63,6 +65,7 @@ func main() {
 		defer close(done)
 		dnsClient := &dns.Client{
 			Timeout: time.Second * 5,
+			Net:     *protocolFlag, // Inserting string value of protocol flag if present to indicate udp, tcp, etc.
 		}
 		for _, peer := range wgDevice.Peers {
 			select {


### PR DESCRIPTION
Added the ability for wgsd-client to accept an optional protocol flag to indicate what protocol to use primarily for use over TCP, such as over a Cloudflare tunnel. Protocol is accepted as a string and passed to dns.Client module as-is. Leaving out the protocol flag causes program to function as it did before modification. Any protocol supported natively by the DNS client should work, but I only tested using the default UDP (with flag and without) and TCP over Cloudflare tunnel.